### PR TITLE
fix CI release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,20 +22,24 @@ jobs:
 
       - name: Compile
         run: |
-          make
+          make compress
 
       - name: Upload artifacts
         if: ${{ success() }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ github.event.repository.name }}--${{ github.sha }}
-          path: RPGMakerPSEnginePS2.elf
+          path: |
+            RPGMakerPSEnginePS2.elf
+            compressed_RPGMakerPSEnginePS2.elf
 
       - name: Create release
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
           title: "Latest development build"
-          files: RPGMakerPSEnginePS2.elf
+          files: |
+            RPGMakerPSEnginePS2.elf
+            compressed_RPGMakerPSEnginePS2.elf


### PR DESCRIPTION
both normal and compressed ELF are dispatched to release section on each change to main branch

useful when people who does not have github account want's to download ELF produced by CI